### PR TITLE
feat: ensure additional filters & sorting persists on a refresh of the Results Page

### DIFF
--- a/frontend/src/components/jsx/BuyPage.jsx
+++ b/frontend/src/components/jsx/BuyPage.jsx
@@ -78,32 +78,20 @@ function BuyPage() {
   }
   
  const handleSearch = async (event) => {
-   event.preventDefault();
+  event.preventDefault();
 
-   const { make, model, condition, zip, distance } = form;
-   if (!make || !model || !condition || !zip || !distance) {
-     logWarning('Search failed: Missing fields.');
-     return
-   }
+  const { make, model, condition, zip, distance } = form;
+  if (!make || !model || !condition || !zip || !distance) {
+    logWarning('Search failed: Missing fields.');
+    return
+  }
 
-   const params = {
-     make,
-     model,
-     condition,
-     zip,
-     distance
-   }
-
-   fetchListings(params).then(data => {
-     navigate('/results', {state: {
-       listings: data,
-       makes,
-       models,
-       filters: form
-     }});
-   })
+  navigate('/results', {state: {
+    makes,
+    models,
+    filters: form
+  }});
  }
-
 
   return (
     <div id='buy-page'>

--- a/frontend/src/components/jsx/ResultsPage.jsx
+++ b/frontend/src/components/jsx/ResultsPage.jsx
@@ -18,22 +18,19 @@ function ResultsPage() {
   const navigate = useNavigate();
 
   const [form, setForm] = useState({
-    ...filters,
     color: '',
     minYear: '',
     maxYear: '',
     maxMileage: '',
     minPrice: '',
     maxPrice: '',
-    sortOption: ''
+    sortOption: '',
+    ...filters,
   })
 
   const [models, setModels] = useState(info.state.models);
   const [isSearchFavorited, setIsSearchFavorited] = useState(false);
-  const [listingsInfo, setListingsInfo] = useState({
-    listings: info.state.listings.records,
-    totalListingsCount: info.state.listings.totalCount 
-  });
+  const [listingsInfo, setListingsInfo] = useState({});
   const [page, setPage] = useState(1);
   const [searchChange, setSearchChange] = useState(false);
   
@@ -56,6 +53,10 @@ function ResultsPage() {
       handleSearch();
     }
   }, [form.sortOption])
+
+  useEffect(() => {
+    handleSearch();
+  }, [])
 
   const handleSearchFavoriteClick = (event) => {
     setIsSearchFavorited(prev => !prev);
@@ -128,6 +129,13 @@ function ResultsPage() {
       } else {
         setListingsInfo(prev => ({...prev, listings: [...prev.listings, ...listings], totalListingsCount: listingCount }))
       }
+
+      navigate('/results', {state: {
+        filters: form,
+        listings: listingsInfo.listings,
+        makes,
+        models
+      }})
   
       setSearchChange(false);
     })


### PR DESCRIPTION
## Description

- On a refresh of the Results Page, any additional filters & sorting persists
  
## Milestones
This works towards the 'Buyer can search for specific makes & models with optional filtering and sorting' user story

## Test Plan
<div>
    <a href="https://www.loom.com/share/2686c2c13ba94bf0bc209a3fdc80ed72">
      <p>Demo Video</p>
    </a>
    <a href="https://www.loom.com/share/2686c2c13ba94bf0bc209a3fdc80ed72">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/2686c2c13ba94bf0bc209a3fdc80ed72-4fbd1521c9fc1a0c-full-play.gif">
    </a>
  </div>