### PR TITLE
feat: allow cycling of images on Single Car Page

### DIFF
--- a/frontend/src/components/css/SingleCarPage.css
+++ b/frontend/src/components/css/SingleCarPage.css
@@ -27,9 +27,24 @@
   gap: 20px;
 }
 
+#image-cycler {
+  display: flex;
+  justify-content: center;
+  gap: 50px;
+}
+
 #single-car-image {
   width: 100%;
   border-radius: 25px;
+}
+
+#previous-image {
+  transform: scaleX(-1);
+}
+
+#previous-image,
+#next-image {
+  height: 5vh;
 }
 
 #single-car-title {

--- a/frontend/src/components/jsx/SingleCarPage.jsx
+++ b/frontend/src/components/jsx/SingleCarPage.jsx
@@ -21,6 +21,8 @@ function SingleCarPage() {
   const [listing, setListing] = useState(null);
   const [isFavorited, setIsFavorited] = useState(false);
 
+  const [imageIndex, setImageIndex] = useState(0);
+
   // ON BOOT
   useEffect(() => {
     const boot = async () => {
@@ -129,6 +131,14 @@ function SingleCarPage() {
       logError(`Something went wrong when trying to favorite listing with VIN: ${vin}`, error)
     }
   }
+
+  const handleNextImage = () => {
+    setImageIndex(prev => (prev + 1) % listing.images.length);
+  }
+
+  const handlePreviousImage = () => {
+    setImageIndex(prev => (prev - 1 + listing.images.length) % listing.images.length);
+  }
   
   if (!listing) {
     return <div>Loading...</div>
@@ -146,7 +156,11 @@ function SingleCarPage() {
         <div id='main-content'>
           <div id='listing-container'>
             <div id='listing-info'>
-              <img src={listing.images[0]} id='single-car-image'/>
+              <img src={listing.images[imageIndex]} id='single-car-image'/>
+              <div id='image-cycler'>
+                <img src={arrow} id='previous-image' className='pointer' onClick={handlePreviousImage}/>
+                <img src={arrow} id='next-image' className='pointer' onClick={handleNextImage}/>
+              </div>
               <p id='single-car-title'><strong>{listing.year} {listing.make} {listing.model}</strong></p>
               <p className='single-car-info'><strong>Condition: </strong>{formattedCondition}</p>
               <p className='single-car-info'><strong>Miles: </strong>{formattedMiles}</p>


### PR DESCRIPTION
## Description

- Users have the ability to cycle through all of listing images when inside of the Single Car Page

## Test Plan
<div>
    <a href="https://www.loom.com/share/62ff350c848b46f9afb8d2e3a473e4f3">
      <p>Demo Video</p>
    </a>
    <a href="https://www.loom.com/share/62ff350c848b46f9afb8d2e3a473e4f3">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/62ff350c848b46f9afb8d2e3a473e4f3-ccee7751ebb79aca-full-play.gif">
    </a>
  </div>