### PR TITLE
fix: handle empty listings in recommendation fetching logic

### DIFF
--- a/backend/services/fetchRelevantListingsService.js
+++ b/backend/services/fetchRelevantListingsService.js
@@ -35,8 +35,6 @@ async function fetchListingsFromSearchHistory(userId) {
 
   if (searchesResponse.status === 200) {
     pastSearches = searchesResponse.searches;
-  } else if (searchesResponse.status === 404) {
-    return null;
   } else {
     return searchesResponse.message;
   }

--- a/backend/services/recommendationService.js
+++ b/backend/services/recommendationService.js
@@ -7,19 +7,17 @@ const calculateRecommendationScore = require('../utils/scoringUtils')
 async function getRecommendations(userId, userLatitude, userLongitude) {
 
   const cached = await getCachedRecommendations(userId);
-  if (cached) return cached;
+  if (Array.isArray(cached) && cached.length > 0) return cached;
   
   const allListings = []
   const recentlyClickedListings = await fetchRecentlyClickedListings(userId, 50);
   if (recentlyClickedListings.status === 200) {
-    for (const listing of recentlyClickedListings.listings) {
-      allListings.push(listing)
-    }
+    allListings.push(...recentlyClickedListings.listings)
   }
 
   const recentlySearchedListings = await fetchListingsFromSearchHistory(userId);
-  for (const listing of recentlySearchedListings) {
-    allListings.push(listing)
+  if (Array.isArray(recentlySearchedListings)) {
+    allListings.push(...recentlySearchedListings)
   }
 
   const uniqueListings = Array.from(new Map(allListings.map(listing => [listing.vin, listing])).values());


### PR DESCRIPTION
## Description
- Correct the cached recommendations check to properly handle cached arrays
- Handle a bad return when fetching past searched listings
- IN PROGRESS: new users don't have favorited or recently clicked & searched listings, so Home Page is practically empty. i have to fix this...