### PR TITLE
feat: add pagination and sorting capabilties; fix: only show non-sold listings & correct visual favorited state of listings

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.10.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.2"
+        "react-router-dom": "^7.6.2",
+        "zipcodes": "^8.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -887,13 +888,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
-      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -901,9 +902,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3134,6 +3135,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zipcodes": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/zipcodes/-/zipcodes-8.0.0.tgz",
+      "integrity": "sha512-V8NolFaJhsPamGeCv5lJdk60Q7JBiXI6e+8JDksPC1NJWZ0t7g1OFfqVLZb2Nc2F5jmf9JTdYdWJBnIhGBvtbA==",
+      "license": "BSD"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.2"
+    "react-router-dom": "^7.6.2",
+    "zipcodes": "^8.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/frontend/src/components/css/ResultsPage.css
+++ b/frontend/src/components/css/ResultsPage.css
@@ -75,14 +75,6 @@
   gap: 20px;
 }
 
-#sort-menu {
-  border: none;
-  border-radius: 10px;
-  align-self: end;
-  padding: .5vh .5vw;
-  margin-right: 50px;
-}
-
 #load-more-button:hover {
   border: 1px solid;
 }

--- a/frontend/src/components/css/SortMenu.css
+++ b/frontend/src/components/css/SortMenu.css
@@ -1,0 +1,7 @@
+#sort-menu {
+  border: none;
+  border-radius: 10px;
+  align-self: end;
+  padding: .5vh .5vw;
+  margin-right: 50px;
+}

--- a/frontend/src/components/jsx/Listing.jsx
+++ b/frontend/src/components/jsx/Listing.jsx
@@ -1,7 +1,7 @@
 import './../css/Listing.css'
 import heart from './../../assets/heart.png'
 import pinkHeart from './../../assets/pinkHeart.png'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { baseURL } from '../../globals'
 import { logError } from '../../utils/logging.service'
@@ -12,6 +12,10 @@ function Listing({ listingData, favoritedOnLoad }) {
   const navigate = useNavigate();
   // TODO: check if listing is already favorited from backend and set this to intial val
   const [isFavorited, setIsFavorited] = useState(favoritedOnLoad);
+
+  useEffect(() => {
+    setIsFavorited(favoritedOnLoad)
+  }, [favoritedOnLoad])
 
   const carTitle = `${listingData.year} ${listingData.make} ${listingData.model}`
   const carLocation = `${listingData.city}, ${listingData.state}`

--- a/frontend/src/components/jsx/ResultsPage.jsx
+++ b/frontend/src/components/jsx/ResultsPage.jsx
@@ -34,6 +34,7 @@ function ResultsPage() {
 
   const [models, setModels] = useState(cachedModels);
   const [listingsInfo, setListingsInfo] = useState(cachedListings ? { listings: cachedListings, totalListingsCount: cachedListings.length } : {});
+  const [displayedListings, setDisplayedListings] = useState(cachedListings?.slice(0, 20) || [])
   const [favoritedVins, setFavoritedVins] = useState([]);
   const [page, setPage] = useState(1);
   const [searchChange, setSearchChange] = useState(false);
@@ -115,6 +116,8 @@ function ResultsPage() {
 
 
   const handlePageChange = () => {
+    const addedListings = listingsInfo.listings.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+    setDisplayedListings(prev => [...prev, ...addedListings])
     setPage(prev => prev + 1);
   }
 
@@ -183,7 +186,7 @@ function ResultsPage() {
         const listingCount = allListings.length;
     
         setListingsInfo({ listings: allListings, totalListingsCount: listingCount });
-    
+        setDisplayedListings(allListings.slice(0, PAGE_SIZE))
         setSearchChange(false);
       } else {
         setListingsInfo({ listings: [], totalListingsCount: 0 })
@@ -347,7 +350,7 @@ function ResultsPage() {
           </select>
           <div id='car-listing-list'>
             {
-              listingsInfo.listings?.length > 0 && listingsInfo.listings.map(listing => {
+              displayedListings.length > 0 && displayedListings.map(listing => {
                 return <Listing key={listing.vin} listingData={listing} favoritedOnLoad={favoritedVins.includes(listing.vin)}/>
               })
             }

--- a/frontend/src/components/jsx/ResultsPage.jsx
+++ b/frontend/src/components/jsx/ResultsPage.jsx
@@ -3,11 +3,13 @@ import heart from './../../assets/heart.png'
 import pinkHeart from './../../assets/pinkHeart.png'
 import Header from './Header'
 import Listing from './Listing'
+import SortMenu from './SortMenu'
 import { baseURL } from '../../globals'
 import { useState, useEffect } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { logInfo, logWarning, logError } from './../../utils/logging.service';
 import { fetchListings, getModels } from '../../utils/api'
+import { sortListings } from './../../utils/listings'
 import { PAGE_SIZE } from '../../utils/constants'
 import axios from 'axios'
 
@@ -16,7 +18,7 @@ function ResultsPage() {
   const navigate = useNavigate();
   
   const cachedRecentSearch = JSON.parse(localStorage.getItem('recentSearch'));
-  const { filters: cachedFilters, listings: cachedListings, makes, models: cachedModels } = cachedRecentSearch;
+  const { filters: cachedFilters, sortOption: cachedSortOption, listings: cachedListings, makes, models: cachedModels } = cachedRecentSearch;
 
   const initialFilters = {
     color: '',
@@ -25,7 +27,6 @@ function ResultsPage() {
     maxMileage: '',
     minPrice: '',
     maxPrice: '',
-    sortOption: '',
     ...cachedFilters
   }
 
@@ -34,9 +35,11 @@ function ResultsPage() {
 
   const [models, setModels] = useState(cachedModels);
   const [listingsInfo, setListingsInfo] = useState(cachedListings ? { listings: cachedListings, totalListingsCount: cachedListings.length } : {});
+  const [listingsUpdated, setListingsUpdated] = useState(false);
   const [displayedListings, setDisplayedListings] = useState(cachedListings?.slice(0, 20) || [])
   const [favoritedVins, setFavoritedVins] = useState([]);
   const [page, setPage] = useState(1);
+  const [sortOption, setSortOption] = useState(cachedSortOption || "");
   const [searchChange, setSearchChange] = useState(false);
   
   const [savedPreferences, setSavedPreferences] = useState([]);
@@ -55,12 +58,6 @@ function ResultsPage() {
     }
     checkAuth();
   }, [navigate]);
-
-  useEffect(() => {
-    if (onScreenFilters.sortOption != '') {
-      handleSort();
-    }
-  }, [onScreenFilters.sortOption])
 
   useEffect(() => {
     const fetchData = async () => {
@@ -132,9 +129,7 @@ function ResultsPage() {
   }
 
   const updateForm = async (event) => {
-    if (event.target.name != 'sortOption') {
-      setSearchChange(true);
-    }
+    setSearchChange(true);
     const elem = event.target.name;
     const value = event.target.value;
     setOnScreenFilters(prev => ({...prev, [elem]: value}));
@@ -147,6 +142,13 @@ function ResultsPage() {
   useEffect(() => {
     updateListings(activeFilters)
   }, [activeFilters])
+
+  useEffect(() => {
+    if (sortOption) {
+      handleSort(sortOption)
+    }
+    setListingsUpdated(false);
+  }, [sortOption, listingsUpdated])
 
   const updateListings = async (activeFilters) => {
 
@@ -171,8 +173,7 @@ function ResultsPage() {
       maxYear: activeFilters.maxYear,
       maxMileage: activeFilters.maxMileage,
       minPrice: activeFilters.minPrice, 
-      maxPrice: activeFilters.maxPrice,
-      sortOption: activeFilters.sortOption
+      maxPrice: activeFilters.maxPrice
     }
 
     try {
@@ -182,11 +183,14 @@ function ResultsPage() {
       ])
     
       if (allListings) {
-        localStorage.setItem('recentSearch', JSON.stringify( { filters: activeFilters, listings: allListings, makes, models }))
+        localStorage.setItem('recentSearch', JSON.stringify( { filters: activeFilters, sortOption, listings: allListings, makes, models }))
         const listingCount = allListings.length;
     
         setListingsInfo({ listings: allListings, totalListingsCount: listingCount });
-        setDisplayedListings(allListings.slice(0, PAGE_SIZE))
+        setListingsUpdated(true);
+        if (!sortOption) {
+          setDisplayedListings(allListings.slice(0, PAGE_SIZE))
+        }
         setSearchChange(false);
       } else {
         setListingsInfo({ listings: [], totalListingsCount: 0 })
@@ -211,8 +215,7 @@ function ResultsPage() {
       maxYear: pref.maxYear,
       maxMileage: pref.maxMileage,
       minPrice: pref.minPrice, 
-      maxPrice: pref.maxPrice,
-      sortOption: onScreenFilters.sortOption
+      maxPrice: pref.maxPrice
     }
 
     const models = await getModels(updatedFilters.make);
@@ -231,8 +234,17 @@ function ResultsPage() {
     setSearchChange(false);
   }
 
-  const handleSort = () => {
+  const handleSort = async (newSortOption) => {
+    localStorage.setItem('recentSearch', JSON.stringify( { filters: activeFilters, sortOption: newSortOption, listings: listingsInfo.listings, makes, models }))
 
+    if (!listingsInfo?.listings?.length) return;
+
+    const [field, order] = newSortOption.split(':');
+
+    const sortedListings = sortListings(listingsInfo.listings, field, order, activeFilters.zip);
+
+    setListingsInfo({ listings: sortedListings, totalListingsCount: sortedListings.length })
+    setDisplayedListings(sortedListings.slice(0, page * PAGE_SIZE));
   }
 
   const colors = ['beige', 'black', 'blue', 'brown', 'gold', 'gray', 'green', 'orange', 'purple', 'red', 'silver', 'white', 'yellow'];
@@ -337,17 +349,7 @@ function ResultsPage() {
           }
         </div>
         <div id='result-page-listings-content'>
-          <select className='translucent pointer' id='sort-menu' value={onScreenFilters.sortOption} name='sortOption' onChange={updateForm}>
-            <option value="" disabled>Sort By: </option>
-            <option value="price:asc">Price (Least Expensive First)</option>
-            <option value="price:desc">Price (Most Expensive First)</option>
-            <option value="distance:asc">Distance (Nearest First)</option>
-            <option value="year:desc">Year (Newest First)</option>
-            <option value="year:asc">Year (Oldest First)</option>
-            <option value="mileage:asc">Mileage (Lowest First)</option>
-            <option value="created_at:desc">Time on Market (Shortest First)</option>
-            <option value="created_at:asc">Time on Market (Longest First)</option>
-          </select>
+          <SortMenu sortOption={sortOption} onChange={setSortOption} />
           <div id='car-listing-list'>
             {
               displayedListings.length > 0 && displayedListings.map(listing => {

--- a/frontend/src/components/jsx/SortMenu.jsx
+++ b/frontend/src/components/jsx/SortMenu.jsx
@@ -1,0 +1,20 @@
+import './../css/SortMenu.css'
+
+function SortMenu({ sortOption, onChange }) {
+  
+  return (
+    <select className='translucent pointer' id='sort-menu' value={sortOption} name='sortOption' onChange={(e) => onChange(e.target.value)}>
+      <option value="" disabled>Sort By: </option>
+      <option value="price:asc">Price (Least Expensive First)</option>
+      <option value="price:desc">Price (Most Expensive First)</option>
+      <option value="distance:asc">Distance (Nearest First)</option>
+      <option value="year:desc">Year (Newest First)</option>
+      <option value="year:asc">Year (Oldest First)</option>
+      <option value="mileage:asc">Mileage (Lowest First)</option>
+      <option value="createdAt:desc">Time on Market (Shortest First)</option>
+      <option value="createdAt:asc">Time on Market (Longest First)</option>
+    </select>
+  )
+}
+
+export default SortMenu

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -8,4 +8,7 @@ export const CAPITALIZE = (sentence) => {
   return splitSentence.join(' ');
 }
 
+export const EARTH_RADIUS_MILES = 3_959;
+export const RADIANS_PER_DEGREE = Math.PI / 180;
+
 export const PAGE_SIZE = 20;

--- a/frontend/src/utils/geo.js
+++ b/frontend/src/utils/geo.js
@@ -1,0 +1,26 @@
+import { EARTH_RADIUS_MILES, RADIANS_PER_DEGREE } from './constants';
+
+// Haversine formula - EXTERNAL CODE
+export function getProximity(latA, lonA, latB, lonB) {
+
+  const deltaLatitudeRadians = degreesToRadians(latB - latA);
+  const deletaLongitudeRadians = degreesToRadians(lonB - lonA);
+
+  const latARadians = degreesToRadians(latA);
+  const latBRadians = degreesToRadians(latB);
+
+  const halfChordSq = Math.sin(deltaLatitudeRadians / 2) ** 2 +
+                      Math.cos(latARadians) * 
+                      Math.cos(latBRadians) *
+                      Math.sin(deletaLongitudeRadians / 2) ** 2;
+
+  const centralAngle = 2 * Math.atan2(Math.sqrt(halfChordSq), Math.sqrt(1 - halfChordSq));
+
+  const distanceInMiles = EARTH_RADIUS_MILES * centralAngle;
+
+  return distanceInMiles
+}
+
+function degreesToRadians(degrees) {
+  return degrees * RADIANS_PER_DEGREE;
+}

--- a/frontend/src/utils/listings.js
+++ b/frontend/src/utils/listings.js
@@ -1,0 +1,33 @@
+import zipcodes from 'zipcodes'
+import { getProximity } from "./geo";
+
+export function sortListings(listings, field, order, zip) {
+
+  const sortedListings = [...listings];
+
+  sortedListings.sort((a, b) => {
+    let valA = null;
+    let valB = null;
+
+    if (field === 'distance') {       
+      const { latitude: userLatitude, longitude: userLongitude } = zipcodes.lookup(zip); 
+      valA = getProximity(userLatitude, userLongitude, a.latitude, a.longitude);
+      valB = getProximity(userLatitude, userLongitude, b.latitude, b.longitude);
+    } else if (field === 'createdAt') {
+      valA = new Date(a.createdAt);
+      valB = new Date(b.createdAt);
+    } else {
+      valA = a[field];
+      valB = b[field];
+    }
+
+    if (valA < valB) {
+      return order === 'asc' ? -1 : 1;
+    } else if (valA > valB) {
+      return order === 'asc' ? 1 : -1;
+    }
+    return 0;
+  })
+
+  return sortedListings;
+}


### PR DESCRIPTION
## Description
- Add pagination: 20 listings at a time
- Fix bug where heart icon would not illuminate on a refresh despite listing(s) being favorited on the Results Page
- Allow users to sort listings
- Display only non-sold listings on the Results Page
- Working towards making the default ZIP code the user's location instead of a hardcoded value

## Test Plan
[Demo Video](https://drive.google.com/file/d/17jPT5CPyJrAAuFmb9q_EBldaMWPLufj-/view?usp=sharing)