### PR TITLE
fix: make listing views unique for recommendation algorithm purposes

### DIFF
--- a/backend/prisma/migrations/20250718183033_remove_views_field_from_listing_model/migration.sql
+++ b/backend/prisma/migrations/20250718183033_remove_views_field_from_listing_model/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `views` on the `Listing` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Listing" DROP COLUMN "views";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -72,7 +72,6 @@ model Listing {
   soldAt                       DateTime?
   owner                        User?               @relation("owner", fields: [ownerId], references: [id])
   ownerId                      Int?
-  views                        Int                 @default(0)
   favorites                    Int                 @default(0)
 
   favoriters                   User[]              @relation("favoriter")

--- a/backend/services/listingDataService.js
+++ b/backend/services/listingDataService.js
@@ -2,7 +2,6 @@ const { PrismaClient } = require('@prisma/client')
 const prisma = new PrismaClient()
 const { logInfo, logError } = require('../../frontend/src/utils/logging.service')
 
-
 async function getGlobalMessagesCount(listingId, ownerId) {
   try {
     if (!ownerId) {
@@ -32,8 +31,23 @@ async function getGlobalMessagesCount(listingId, ownerId) {
   }
 }
 
-function getGlobalTotalClicks(listing) {
-  return listing.views;
+async function getGlobalViewCount(listingId) {
+  try {
+    const listingVisits = await prisma.listingVisit.findMany({
+      where: { listingId }
+    })
+
+    if (!listingVisits) {
+      logInfo(`Listing with listingId: ${listingId} has no previous views`)
+      return ({ status: 404, viewCount: 0 })
+    }
+
+    logInfo(`Listing with listingId: ${listingId} has ${listingVisits.length} views`)
+    return ({ status: 200, viewCount: listingVisits.length })
+  } catch (error) {
+    logError(`Something bad happened trying to retrieve the number of views of listing with listingId: ${listingId}`, error);
+    return ({ status: 500, viewCount: 0 })
+  }
 }
 
 function getGlobalFavorites(listing) {
@@ -168,7 +182,7 @@ function getProximityToUser(listingLatitude, listingLongitude, userLatitude, use
 
 module.exports = {
   getGlobalMessagesCount,
-  getGlobalTotalClicks,
+  getGlobalViewCount,
   getGlobalFavorites,
   hasUserMessagedSeller,
   hasUserFavoritedListing,

--- a/backend/services/recommendationService.js
+++ b/backend/services/recommendationService.js
@@ -32,8 +32,8 @@ async function getRecommendations(userId, userLatitude, userLongitude) {
     uniqueListingInfo.globalMessageCount = listing.ownerId ? (await listingDataService.getGlobalMessagesCount(listing.id, listing.ownerId)).count : 0;
     uniqueListingInfo.hasUserMessagedSeller = listing.ownerId ? (await listingDataService.hasUserMessagedSeller(listing.id, listing.ownerId, userId)).hasMessaged : 0;
 
-    uniqueListingInfo.globalTotalClicks = listingDataService.getGlobalTotalClicks(listing);
-    uniqueListingInfo.globalTotalClicksPerDay = calculateValuePerDay(uniqueListingInfo.globalTotalClicks, daysOnMarket);
+    uniqueListingInfo.globalViewCount = (await listingDataService.getGlobalViewCount(listing.id)).views;
+    uniqueListingInfo.globalViewCountPerDay = calculateValuePerDay(uniqueListingInfo.globalViewCount, daysOnMarket);
 
     uniqueListingInfo.globalFavorites = listingDataService.getGlobalFavorites(listing);
     uniqueListingInfo.globalFavoritesPerDay = calculateValuePerDay(uniqueListingInfo.globalFavorites, daysOnMarket)
@@ -55,7 +55,7 @@ async function getRecommendations(userId, userLatitude, userLongitude) {
 
   const maxValues = {
     globalMessageCount: Math.max(...uniqueListingsInfo.map(info => info.globalMessageCount)),
-    globalTotalClicks: Math.max(...uniqueListingsInfo.map(info => info.globalTotalClicks)),
+    globalViewCount: Math.max(...uniqueListingsInfo.map(info => info.globalViewCount)),
     globalTotalClicksPerDay: Math.max(...uniqueListingsInfo.map(info => info.globalTotalClicksPerDay)),
     globalFavorites: Math.max(...uniqueListingsInfo.map(info => info.globalFavorites)),
     globalFavoritesPerDay: Math.max(...uniqueListingsInfo.map(info => info.globalFavoritesPerDay)),
@@ -73,8 +73,8 @@ async function getRecommendations(userId, userLatitude, userLongitude) {
       ownerId: info.ownerId,
       globalMessageCount: normalizeValue(info.globalMessageCount, maxValues.globalMessageCount),
       hasUserMessagedSeller: info.hasUserMessagedSeller === true ? 1 : 0,
-      globalTotalClicks: normalizeValue(info.globalTotalClicks, maxValues.globalTotalClicks),
-      globalTotalClicksPerDay: normalizeValue(info.globalTotalClicksPerDay, maxValues.globalTotalClicksPerDay),
+      globalViewCount: normalizeValue(info.globalViewCount, maxValues.globalViewCount),
+      globalViewCountPerDay: normalizeValue(info.globalViewCountPerDay, maxValues.globalViewCountPerDay),
       globalFavorites: normalizeValue(info.globalFavorites, maxValues.globalFavorites),
       globalFavoritesPerDay: normalizeValue(info.globalFavoritesPerDay, maxValues.globalFavoritesPerDay),
       hasUserFavoritedListing: info.hasUserFavoritedListing === true ? 1 : 0,

--- a/backend/utils/scoringUtils.js
+++ b/backend/utils/scoringUtils.js
@@ -3,8 +3,8 @@ function calculateRecommendationScore(normalizedSignals) {
   const weightsForUserCreatedListings = {
     globalMessageCount: 0.08,
     hasUserMessagedSeller: 0.10,
-    globalTotalClicks: 0.10,
-    globalTotalClicksPerDay: 0.04,
+    globalViewCount: 0.10,
+    globalViewCountPerDay: 0.04,
     globalFavorites: 0.08,
     globalFavoritesPerDay: 0.04,
     hasUserFavoritedListing: 0.10,


### PR DESCRIPTION
## Description
- Make the metric for listing views unique per user for the recommendation algorithm
- Combat sellers trying to inflate their views by spam-clicking their own listing which can inherently make it so that their listing is more often recommended (Thanks @rohanv0 for bringing this to my attention)

## Milestones
This works towards the 'Buyer can see cars recommended to them based on their previous activity' user story