### PR TITLE
refactor: remove fallback to when listing has no owner

### DIFF
--- a/backend/services/listingDataService.js
+++ b/backend/services/listingDataService.js
@@ -4,11 +4,6 @@ const { logInfo, logError } = require('../../frontend/src/utils/logging.service'
 
 async function getGlobalMessagesCount(listingId, ownerId) {
   try {
-    if (!ownerId) {
-      logInfo(`Listing with listingId: ${listingId} cannot receive messages`)
-      return ({ status: 404, count: 0 })
-    }
-
     const messages = await prisma.message.findMany({
       where: {
         listingId,
@@ -54,12 +49,8 @@ function getGlobalFavorites(listing) {
   return listing.favorites;
 }
 
-async function hasUserMessagedSeller(listingId, ownerId, userId) {
+async function hasUserMessagedSeller(listingId, userId) {
   try {
-    if (!ownerId) {
-      logInfo(`Listing with listingId: ${listingId} cannot receive messages`)
-      return ({ status: 404, hasMessaged: false })
-    }
 
     const hasMessaged = await prisma.message.findFirst({
       where: {

--- a/backend/services/recommendationService.js
+++ b/backend/services/recommendationService.js
@@ -29,8 +29,8 @@ async function getRecommendations(userId, userLatitude, userLongitude) {
 
     const uniqueListingInfo = { listingId: listing.id, ownerId: listing.ownerId };
 
-    uniqueListingInfo.globalMessageCount = listing.ownerId ? (await listingDataService.getGlobalMessagesCount(listing.id, listing.ownerId)).count : 0;
-    uniqueListingInfo.hasUserMessagedSeller = listing.ownerId ? (await listingDataService.hasUserMessagedSeller(listing.id, listing.ownerId, userId)).hasMessaged : 0;
+    uniqueListingInfo.globalMessageCount = (await listingDataService.getGlobalMessagesCount(listing.id, listing.ownerId)).count;
+    uniqueListingInfo.hasUserMessagedSeller = (await listingDataService.hasUserMessagedSeller(listing.id, userId)).hasMessaged;
 
     uniqueListingInfo.globalViewCount = (await listingDataService.getGlobalViewCount(listing.id)).viewCount;
     uniqueListingInfo.globalViewCountPerDay = calculateValuePerDay(uniqueListingInfo.globalViewCount, daysOnMarket);

--- a/backend/utils/scoringUtils.js
+++ b/backend/utils/scoringUtils.js
@@ -1,6 +1,6 @@
 
 function calculateRecommendationScore(normalizedSignals) {
-  const weightsForUserCreatedListings = {
+  const weights = {
     globalMessageCount: 0.08,
     hasUserMessagedSeller: 0.10,
     globalViewCount: 0.10,
@@ -14,14 +14,7 @@ function calculateRecommendationScore(normalizedSignals) {
     userEngagementClicksPerDay: 0.06,
     proximityToUser: 0.10,
     daysOnMarket: 0.05
-  }  
-
-  const weightsForNonUserCreatedListings = {};
-  for (const key in weightsForUserCreatedListings) {
-    weightsForNonUserCreatedListings[key] = weightsForUserCreatedListings[key] / .82; // 18% is lost because users cannot send messages on non-user-created listings
   }
-
-  const weights = normalizedSignals.ownerId ? weightsForUserCreatedListings : weightsForNonUserCreatedListings;
 
   let score = 0;
   for (const key in weights) {

--- a/frontend/src/components/jsx/HomePage.jsx
+++ b/frontend/src/components/jsx/HomePage.jsx
@@ -40,7 +40,7 @@ function HomePage() {
           axios.get(`${baseURL}/api/listings/recommended`, { withCredentials: true }),
           axios.get(`${baseURL}/api/listings/user/favorited`, { withCredentials: true }),
           axios.get(`${baseURL}/api/track/most-recently-visited-listings/20`, { withCredentials: true }),
-          axios.get(`${baseURL}/api/listings/popular`)
+          axios.get(`${baseURL}/api/listings/popular`, { withCredentials: true })
         ]);
   
         setRecommendedListings(recommendedListingsResponse.data);

--- a/frontend/src/components/jsx/Listing.jsx
+++ b/frontend/src/components/jsx/Listing.jsx
@@ -33,33 +33,6 @@ function Listing({ listingData, favoritedOnLoad }) {
         const favorited = listing.favoriters.some(favoriter => favoriter.id === userId);
         await axios.patch(`${baseURL}/api/listings/${listingData.vin}/favorite`, {}, { withCredentials: true })
         setIsFavorited(!favorited);
-      } else if (response.data.status === 404) {
-        const listingResponse = await axios.get(`${baseURL}/api/listings/${listingData.vin}/data`);
-        const listingInfo = listingResponse.data;
-        const newListingInfo = {
-          condition: listingInfo.condition || 'N/A',
-          make: listingInfo.make || 'N/A',
-          model: listingInfo.model || 'N/A',
-          year: listingInfo.year?.toString() || 'N/A',
-          color: listingInfo.exteriorColor || 'N/A',
-          mileage: listingInfo.mileage?.toString() || 'N/A',
-          vin: listingInfo.vin,
-          description: listingInfo.description || 'N/A',
-          images: listingInfo.photoUrls,
-          price: listingInfo.price?.toString() || 'N/A',
-          zip: listingInfo.zip || 'N/A',
-          owner_name: listingInfo.dealerName || 'N/A',
-          owner_number: listingInfo.phoneTel || 'N/A',
-          city: listingInfo.city || 'N/A',
-          state: listingInfo.state || 'N/A',
-          latitude: listingInfo.latitude || 0,
-          longitude: listingInfo.longitude || 0,
-          createdAt: listingInfo.createdAt,
-          views: 0
-        }
-        const newListing = await axios.post(`${baseURL}/api/listings`, newListingInfo);
-        await axios.patch(`${baseURL}/api/listings/${listingData.vin}/favorite`, {}, { withCredentials: true })
-        setIsFavorited(true);
       }
     } catch (error) {
       logError(`Something went wrong when trying to favorite listing with VIN: ${listingData.vin}`, error)

--- a/frontend/src/components/jsx/SellPage.jsx
+++ b/frontend/src/components/jsx/SellPage.jsx
@@ -83,10 +83,6 @@ function SellPage() {
     fetchOwnedListings();
   }, [])
   
-  const handleLogout = () => {
-    // call axios backend logout endpoint
-  }
-  
   const updateForm = async (event) => {
     const elem = event.target.name;
 

--- a/frontend/src/components/jsx/SingleCarPage.jsx
+++ b/frontend/src/components/jsx/SingleCarPage.jsx
@@ -56,33 +56,6 @@ function SingleCarPage() {
             setIsFavorited(favorited);
             listingIdRef.current = listing.id;
             listingOwnerIdRef.current = listing.owner?.id;
-          } else if (response.data.status === 404) {
-            const listingResponse = await axios.get(`${baseURL}/api/listings/${vin}/data`);
-            const listingInfo = listingResponse.data;
-            const newListingInfo = {
-              condition: listingInfo.condition || 'N/A',
-              make: listingInfo.make || 'N/A',
-              model: listingInfo.model || 'N/A',
-              year: listingInfo.year?.toString() || 'N/A',
-              color: listingInfo.exteriorColor || 'N/A',
-              mileage: listingInfo.mileage?.toString() || 'N/A',
-              vin: listingInfo.vin,
-              description: listingInfo.description || 'N/A',
-              images: listingInfo.photoUrls,
-              price: listingInfo.price?.toString() || 'N/A',
-              zip: listingInfo.zip || 'N/A',
-              owner_name: listingInfo.dealerName || 'N/A',
-              owner_number: listingInfo.phoneTel || 'N/A',
-              city: listingInfo.city || 'N/A',
-              state: listingInfo.state || 'N/A',
-              latitude: listingInfo.latitude || 0,
-              longitude: listingInfo.longitude || 0,
-              createdAt: listingInfo.createdAt,
-              views: 1
-            }
-            const newListing = await axios.post(`${baseURL}/api/listings`, newListingInfo);
-            setListing(newListing.data);
-            listingIdRef.current = newListing.data.id;
           }
         } catch (error) {
           logError(`Something went wrong when trying to fetch listing with VIN: ${vin}`, error)


### PR DESCRIPTION
## Description
Before the [migration](https://docs.google.com/document/d/1zT8BpEOUsrUNfDq_FH9GKn6jWorFaT8vrE_Uoy3-buE/edit?usp=sharing), listings either belonged to Auto Dev API or were created manually on Carportal and listing clicks or favorites had to be handled differently based on where the listing came from. This is not necessary any more.

- Remove code where a listing was auto-created if a listing was clicked/favorited and not found in DB
- Remove code where recommendation algorithm had different weights based on if it was manually created or not
- Working towards improving the consistency of variable naming & moving magic numbers to constants file