### PR TITLE
feat: iteration on TC 2

### DIFF
--- a/backend/prisma/migrations/20250723143755_add_competitor_graph_model/migration.sql
+++ b/backend/prisma/migrations/20250723143755_add_competitor_graph_model/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "CompetitorGraph" (
+    "id" SERIAL NOT NULL,
+    "make" TEXT NOT NULL,
+    "model" TEXT NOT NULL,
+    "competitorMake" TEXT NOT NULL,
+    "competitorModel" TEXT NOT NULL,
+    "count" INTEGER NOT NULL,
+
+    CONSTRAINT "CompetitorGraph_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CompetitorGraph_make_model_competitorMake_competitorModel_key" ON "CompetitorGraph"("make", "model", "competitorMake", "competitorModel");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -127,3 +127,13 @@ model Message {
   listing                      Listing             @relation(fields: [listingId], references: [id], onDelete: Cascade)
   listingId                    Int
 }
+
+model CompetitorGraph {
+  id                           Int                 @id @default(autoincrement())
+  make                         String
+  model                        String
+  competitorMake               String
+  competitorModel              String
+  count                        Int
+  @@unique([make, model, competitorMake, competitorModel])
+}

--- a/backend/scripts/rebuildCompetitorGraph.js
+++ b/backend/scripts/rebuildCompetitorGraph.js
@@ -1,0 +1,78 @@
+const { PrismaClient } = require('@prisma/client')
+const { MAX_COMPETITORS } = require('../utils/constants')
+
+const prisma = new PrismaClient();
+
+export async function rebuildCompetitorGraph() {
+  await prisma.competitorGraph.deleteMany();
+
+  const listingVisits = await prisma.listingVisit.findMany({
+    distinct: ['listingId'],
+    include: {
+      listing: {
+        select: {
+          make: true,
+          model: true
+        }
+      }
+    }
+  })
+
+  const distinctMakeModelCombinationsVisited = [...new Set
+    (listingVisits.map(listingVisit => `${listingVisit.listing.model}:${listingVisit.listing.model}`)
+  )].map(makeModelCombination => {
+    const [make, model] = makeModelCombination.split(':');
+    return { make, model }
+  })
+  
+  for (const { make, model } of distinctMakeModelCombinationsVisited) {
+    const users = await prisma.listingVisit.findMany({
+      where: {
+        listing: {
+          make,
+          model
+        }
+      }
+    })
+
+    const userIds = users.map(user => user.userId);
+
+    const userVisits = await prisma.listingVisit.findMany({
+      where: {
+        userId: {
+          in: userIds
+        }
+      },
+      include: {
+        listing: {
+          select: {
+            make: true,
+            model: true
+          }
+        }
+      }
+    })
+
+    const counts = new Map()
+    for (const userVisit of userVisits) {
+      const { competitorMake, competitorModel } = userVisit.listing
+      // Cannot be a competitor to itself
+      if (competitorMake === make && competitorModel === model) {
+        continue;
+      }
+      const key = `${competitorMake}:${competitorModel}`
+      counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+
+    const topCompetitors = [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, MAX_COMPETITORS)
+
+    if (topCompetitors.length !== 0) {
+      await prisma.competitorGraph.createMany({
+        data: topCompetitors.map(([key, count]) => {
+          const [competitorMake, competitorModel] = key.split(':')
+          return { make, model, competitorMake, competitorModel, count }
+        })
+      })
+    }
+  }
+}

--- a/backend/services/fetchRelevantListingsService.js
+++ b/backend/services/fetchRelevantListingsService.js
@@ -2,9 +2,11 @@ const zipcodes = require('zipcodes')
 const { PrismaClient } = require('@prisma/client')
 const prisma = new PrismaClient()
 const { logInfo, logError } = require('../../frontend/src/services/loggingService')
-const { PAGE_SIZE, SIMILARITY_DEPTHS, MINIMUM_COMPS_REQUIRED } = require('../utils/constants')
+const { PAGE_SIZE, SIMILARITY_DEPTHS, MINIMUM_COMPS_REQUIRED, MAX_COMPETITORS } = require('../utils/constants')
 const { getProximity } = require('../utils/geo')
 const getDaysOnMarket = require('../utils/time')
+const { getModels, getCompetitors } = require('./makeModelService')
+const { rebuildCompetitorGraph } = require('../scripts/rebuildCompetitorGraph')
 
 async function fetchRecentlyClickedListings(userId, count) {
  try {
@@ -165,64 +167,66 @@ function calculateBounds(latitude, longitude, radius) {
 }
 
 async function fetchSimilarListings(listingInfo) {
+  await rebuildCompetitorGraph(); // TODO: precompute (maybe run script daily)
   const { condition, make, model, year, mileage, latitude, longitude } = listingInfo;
 
-  let maxDepthReached = null;
-  const comps = new Map();
+  const comps = new Map()
+  const globalDepth = { depth: 1 };
 
-  for (let depth = 0; depth < SIMILARITY_DEPTHS.length; depth++) {
-    const { YEAR_RANGE, MILEAGE_FACTOR } = SIMILARITY_DEPTHS[depth];
+  const scopeSameModel = [{ make, model }]
 
-    let whereClause = {
-      condition,
-      make,
-      model
-    }
-
-    whereClause.year = {
-      gte: year - YEAR_RANGE,
-      lte: year + YEAR_RANGE
-    }
-
-    if (depth < SIMILARITY_DEPTHS.length - 1) {
-      whereClause.mileage = {
-        gte: Math.floor(mileage * (1 - MILEAGE_FACTOR)),
-        lte: Math.ceil(mileage * (1 + MILEAGE_FACTOR))
-      }
-    }
-
-    try {
-      const similarListings = await prisma.listing.findMany({
-        where: whereClause
-      });
+  const sameMakeModels = (await getModels(make)).filter(otherModel => otherModel !== model);
+  const scopeSameMake = sameMakeModels.map(model => ({ make, model: model.name }))
   
-      if (Array.isArray(similarListings)) {
-        similarListings.forEach(listing => {
-          if (!comps.has(listing.id)) {
-            listing.depth = depth + 1;
-            listing.proximity = getProximity(listing.latitude, listing.longitude, latitude, longitude);
-            listing.daysOnMarket = getDaysOnMarket(listing);
-            comps.set(listing.id, listing);
-          }
-        })
+  const scopeCompetitors = (await getCompetitors(make, model, MAX_COMPETITORS)).map(competitor => ({ make: competitor.competitorMake, model: competitor.competitorModel }))
 
-        if (similarListings.length >= MINIMUM_COMPS_REQUIRED) {
-          maxDepthReached = depth + 1;
-          break;
+  const scopes = [scopeSameModel, scopeSameMake, scopeCompetitors]
+
+  for (const scope of scopes) {
+    for (const { YEAR_RANGE, MILEAGE_FACTOR } of SIMILARITY_DEPTHS) {
+
+      let whereClause = {
+        condition,
+        OR: scope,
+        year: {
+          gte: year - YEAR_RANGE,
+          lte: year + YEAR_RANGE
         }
       }
-    } catch (error) {
-      logError('Something bad happened trying to retrieve similar listings', error);
-      return ({ status: 500, message: 'Failed to retrieve similar listings' })
+
+      if (MILEAGE_FACTOR > 0) {
+        whereClause.mileage = {
+          gte: Math.floor(mileage * (1 - MILEAGE_FACTOR)),
+          lte: Math.ceil(mileage * (1 + MILEAGE_FACTOR))
+        }
+      }
+
+      const similarListings = await prisma.listing.findMany({
+        where: whereClause
+      })
+
+      similarListings.forEach(listing => {
+        if (!comps.has(listing.id)) {
+          logInfo(`Found a similar listing: ${listing.year} ${listing.make} ${listing.model} with ${listing.mileage}mi priced at ${listing.price} at depth ${globalDepth.depth}`)
+          listing.depth = toDepthBucket(globalDepth.depth);
+          listing.proximity = getProximity(listing.latitude, listing.longitude, latitude, longitude);
+          listing.daysOnMarket = getDaysOnMarket(listing);
+          comps.set(listing.id, listing);
+        }
+      })
+
+      if (comps.size >= MINIMUM_COMPS_REQUIRED) {
+        return Array.from(comps.values())
+      }
+
+      globalDepth.depth += 1
     }
   }
-  const numberOfListingsFound = comps.size;
-  if (numberOfListingsFound !== 0) {
-    logInfo(`Successfully retrieved ${numberOfListingsFound} similar listings`);
-    return ({ status: 200, depth: maxDepthReached ?? SIMILARITY_DEPTHS.length, listings: [...comps.values()] })
-  }
-  logInfo('No similar listings were found')
-  return ({ status: 404, message: 'No similar listings were found' })
+  return Array.from(comps.values())
+}
+
+function toDepthBucket(depth) {
+  return depth > 10 ? 7 : depth > 5 ? 6 : depth;
 }
 
 module.exports = {

--- a/backend/services/makeModelService.js
+++ b/backend/services/makeModelService.js
@@ -49,4 +49,19 @@ async function getModels(make) {
   })
 }
 
-module.exports = { getMakesAndModels, insertMakesAndModels, getMakes, getModels }
+async function getCompetitors(make, model, limit) {
+  return prisma.competitorGraph.findMany({
+    where: {
+      make,
+      model
+    },
+    orderBy: { count: 'desc' },
+    take: limit,
+    select: {
+      competitorMake: true,
+      competitorModel: true
+    }
+  })
+}
+
+module.exports = { getMakesAndModels, insertMakesAndModels, getMakes, getModels, getCompetitors }

--- a/backend/services/priceEstimatorService.js
+++ b/backend/services/priceEstimatorService.js
@@ -3,43 +3,57 @@ const { logInfo } = require('../../frontend/src/services/loggingService')
 const computeSellerDelta = require('../utils/sellerHistory')
 const { calculateMarketPrice } = require('../utils/statistics')
 const buildElasticityCurve = require('../utils/elasticity')
-const { ROUND_TO_NEAREST_HUNDRED, FORMAT_TO_PRICE } = require('../utils/constants')
+const { ROUND_TO_NEAREST_HUNDRED, FORMAT_TO_PRICE, MINIMUM_COMPS_REQUIRED } = require('../utils/constants')
 
 async function getPriceRecommendationInfo(userAndListingInfo) {
 
   userAndListingInfo.year = parseInt(userAndListingInfo.year);
   userAndListingInfo.mileage = parseInt(userAndListingInfo.mileage);
 
-  const similarListingsResponse = await fetchSimilarListings(userAndListingInfo);
-  const listings = similarListingsResponse.listings;
-  const depth = similarListingsResponse.depth;
+  const { listings, status } = await fetchSimilarListings(userAndListingInfo);
 
-  if (similarListingsResponse.status !== 200) {
+  if (status !== 200) {
     return { estimatedPrice: 0, message: 'Could not find similar listings' }
   }
+
+  const { confidenceLevel, confidenceScore } = getConfidence(listings);
 
   const sellerDelta = await computeSellerDelta(userAndListingInfo.sellerId);
 
   const { marketPrice, enrichedListings } = calculateMarketPrice(listings, userAndListingInfo)
 
   // round to nearest 100
-  const recommendedPrice = ROUND_TO_NEAREST_HUNDRED(marketPrice * (1 + (sellerDelta / depth)));
-
-  const confidenceLevel = getConfidenceLevel(depth);
+  const recommendedPrice = ROUND_TO_NEAREST_HUNDRED(marketPrice * (1 + (sellerDelta * confidenceScore)));
 
   const elasticity = buildElasticityCurve(enrichedListings, recommendedPrice);
 
   return { marketPrice: FORMAT_TO_PRICE(marketPrice), recommendedPrice: FORMAT_TO_PRICE(recommendedPrice), confidenceLevel, elasticity }
 }
 
-function getConfidenceLevel(depth) {
-  const confidenceLevel = depth === 1 ? "very high"
-                          : depth === 2 ? "high"
-                          : depth === 3 ? "medium"
-                          : depth === 4 ? "low"
+function getConfidence(comps) {
+  const quantityWeight = Math.min(1, comps.length / MINIMUM_COMPS_REQUIRED)
+
+  const prices = comps.map(comp => comp.price)
+  const averagePrice = prices.reduce((sum, price) => sum + price, 0) / prices.length
+
+  const variance = prices.reduce((sum, price) => sum + (price - averagePrice) ** 2, 0) / prices.length
+  const stdDeviation = Math.sqrt(variance)
+
+  const scatteredWeight = 1 / (1 + (stdDeviation / averagePrice))
+
+  const averageDepthWeight = comps.reduce((sum, comp) => sum + comp.depth, 0) / comps.length
+
+  const depthQualityWeight = 1 / averageDepthWeight
+
+  const confidenceScore = 3 / ((1 / quantityWeight) + (1 / scatteredWeight) + (1 / depthQualityWeight))
+
+  const confidenceLevel = confidenceScore > 0.85 ? "very high"
+                          : confidenceScore > 0.65 ? "high"
+                          : confidenceScore > 0.45 ? "medium"
+                          : confidenceScore > 0.25 ? "low"
                           : "very low"
-  logInfo(`Confidence Level for the recommended price is ${confidenceLevel.toUpperCase()}`)
-  return confidenceLevel;
+  logInfo(`Confidence Level for the recommended price is ${confidenceLevel.toUpperCase()} with a score of ${confidenceScore}`)
+  return { confidenceLevel, confidenceScore };
 }
 
 module.exports = getPriceRecommendationInfo;

--- a/backend/utils/constants.js
+++ b/backend/utils/constants.js
@@ -10,7 +10,9 @@ const SIMILARITY_DEPTHS = [
   { YEAR_RANGE: 1, MILEAGE_FACTOR: 0.10 },
   { YEAR_RANGE: 3, MILEAGE_FACTOR: 0.30 },
   { YEAR_RANGE: 5, MILEAGE_FACTOR: 0.50 },
-  { YEAR_RANGE: 5, MILEAGE_FACTOR: 0.00 } // no limit on mileage, but still around same generation of make/model
+  { YEAR_RANGE: 5, MILEAGE_FACTOR: 0.00 }, // no limit on mileage, but still around same generation of make/model
+  { SAME_MAKE: true },
+  { COMPETITOR: true }
 ]
 const MINIMUM_COMPS_REQUIRED = 10;
 
@@ -30,8 +32,11 @@ const DEPTH_WEIGHT_BY_LEVEL = {
   2: 1.5,
   3: 0.375,
   4: 0.125,
-  5: 0.025
+  5: 0.025,
+  6: 0.0125,
+  7: 0.008
 };
+const MAX_COMPETITORS = 3;
 const SOLD_LISTING_WEIGHT = .7;
 const UNSOLD_LISTING_WEIGHT = .3;
 const PROXIMITY_MIN_WEIGHT = .25;
@@ -82,6 +87,7 @@ module.exports = {
   SELLER_FACTOR_MAX,
   MILEAGE_SCALE_FACTOR,
   DEPTH_WEIGHT_BY_LEVEL,
+  MAX_COMPETITORS,
   SOLD_LISTING_WEIGHT,
   UNSOLD_LISTING_WEIGHT,
   PROXIMITY_MIN_WEIGHT,

--- a/backend/utils/constants.js
+++ b/backend/utils/constants.js
@@ -10,9 +10,7 @@ const SIMILARITY_DEPTHS = [
   { YEAR_RANGE: 1, MILEAGE_FACTOR: 0.10 },
   { YEAR_RANGE: 3, MILEAGE_FACTOR: 0.30 },
   { YEAR_RANGE: 5, MILEAGE_FACTOR: 0.50 },
-  { YEAR_RANGE: 5, MILEAGE_FACTOR: 0.00 }, // no limit on mileage, but still around same generation of make/model
-  { SAME_MAKE: true },
-  { COMPETITOR: true }
+  { YEAR_RANGE: 5, MILEAGE_FACTOR: 0.00 } // no limit on mileage, but still around same generation of make/model
 ]
 const MINIMUM_COMPS_REQUIRED = 10;
 
@@ -36,6 +34,15 @@ const DEPTH_WEIGHT_BY_LEVEL = {
   6: 0.0125,
   7: 0.008
 };
+const DEPTH_CONFIDENCE_PENALTIES = {
+  1: 1.00,
+  2: 0.90,
+  3: 0.80,
+  4: 0.70,
+  5: 0.60,
+  6: 0.30, // harsh drop (cars within same make)
+  7: 0.20, // continued drop (competitor cars)
+}
 const MAX_COMPETITORS = 3;
 const SOLD_LISTING_WEIGHT = .7;
 const UNSOLD_LISTING_WEIGHT = .3;
@@ -87,6 +94,7 @@ module.exports = {
   SELLER_FACTOR_MAX,
   MILEAGE_SCALE_FACTOR,
   DEPTH_WEIGHT_BY_LEVEL,
+  DEPTH_CONFIDENCE_PENALTIES,
   MAX_COMPETITORS,
   SOLD_LISTING_WEIGHT,
   UNSOLD_LISTING_WEIGHT,

--- a/backend/utils/statistics.js
+++ b/backend/utils/statistics.js
@@ -52,4 +52,18 @@ function calculateMarketPrice(listings, userInfo) {
   return { marketPrice, enrichedListings: listings };
 }
 
-module.exports = { calculateMarketPrice }
+function harmonicMean(arr) {
+  if (!Array.isArray(arr) || arr.length === 0) {
+    return 0;
+  }
+
+  const sumOfReciprocals = { sum: 0 }
+
+  for (const num of arr) {
+    sumOfReciprocals.sum += 1 / num;
+  }
+
+  return arr.length / sumOfReciprocals.sum;
+}
+
+module.exports = { calculateMarketPrice, harmonicMean }

--- a/backend/utils/statistics.js
+++ b/backend/utils/statistics.js
@@ -31,7 +31,7 @@ function calculateMarketPrice(listings, userInfo) {
     const depthWeight = (DEPTH_WEIGHT_BY_LEVEL[listing.depth] / listingCountPerDepth[listing.depth]);
     listing.depthWeight = depthWeight;
   
-    const soldWeight = listing.sold ? SOLD_LISTING_WEIGHT / listingsSoldStatus.numSold : UNSOLD_LISTING_WEIGHT / listingsSoldStatus.numUnsold;
+    const soldStatusWeight = listing.sold ? SOLD_LISTING_WEIGHT / listingsSoldStatus.numSold : UNSOLD_LISTING_WEIGHT / listingsSoldStatus.numUnsold;
     
     const proximityWeight = Math.max(PROXIMITY_MIN_WEIGHT, 1 - (listing.proximity / PROXIMITY_DISTANCE_FADE));
   
@@ -39,7 +39,7 @@ function calculateMarketPrice(listings, userInfo) {
 
     const similarSpecificationWeight = 1 / (1 + yearGap + mileageGap);
   
-    const totalWeight = similarSpecificationWeight * depthWeight * soldWeight * proximityWeight * daysOnMarketWeight;
+    const totalWeight = similarSpecificationWeight * depthWeight * soldStatusWeight * proximityWeight * daysOnMarketWeight;
 
     acc.sum += parseInt(listing.price) * totalWeight;
     acc.weightSum += totalWeight;
@@ -57,13 +57,9 @@ function harmonicMean(arr) {
     return 0;
   }
 
-  const sumOfReciprocals = { sum: 0 }
+  const sumOfReciprocals = arr.reduce((sum, num) => sum + 1 / num, 0);
 
-  for (const num of arr) {
-    sumOfReciprocals.sum += 1 / num;
-  }
-
-  return arr.length / sumOfReciprocals.sum;
+  return arr.length / sumOfReciprocals;
 }
 
 module.exports = { calculateMarketPrice, harmonicMean }

--- a/frontend/src/components/jsx/SellPage.jsx
+++ b/frontend/src/components/jsx/SellPage.jsx
@@ -71,7 +71,7 @@ function SellPage() {
       const { models, success } = await getModels(make)
       if (success) {
         setModels(models);
-        setFilters(prev => ({...prev, model: models[0].name}))
+        setListingInfo(prev => ({...prev, model: models[0].name}))
       } else {
         // TODO: error message component
       }


### PR DESCRIPTION
## Description
- Create CompetitorGraph model where I store make/model and its 3 competitor make/models
  - Look at all users who clicked the root car, count every other make/model that user has clicked, rank by count, and persist the 3 with the highest count
- Add additional fallback when minimum comps are not retrieved using the same make/model as seller's
  - Same Make, Other Models
  - Competitor Makes & Models
- Enhance confidence level to include metrics like price disparity, depths, and number of comps found
- Experimented with weights helping combat against edge cases where:
  - Price disparity is really high, making it hard to make a confident estimate (e.g., 1990 Acura Integra vs 1990 Acura NSX)
    - Exponentially curve the coefficient of variation 
  - Most comps come from deep depths
    - Iteratively lowered depth-penalty table
- Working towards: Precomputing the graph storing competitor make/models, maybe recreate daily?

## Milestones
This works towards the 'Seller gets pricing suggestions based on current market trends' user story.

## Test Plan
<img width="1030" height="618" alt="image" src="https://github.com/user-attachments/assets/2d27fd0e-29af-461a-bb1a-8035e5fcae93" />
