### PR TITLE
style: refine sizing and remove floating elements

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -27,7 +27,7 @@ select:focus {
 
 .grow:hover {
   transform: scale(1.05);
-  box-shadow: 0 0 25px lightskyblue;
+  box-shadow: 0 0 20px lightskyblue;
 }
 
 .listings-container {

--- a/frontend/src/components/css/BuyPage.css
+++ b/frontend/src/components/css/BuyPage.css
@@ -2,6 +2,9 @@
   min-width: 99vw;
   min-height: 100vh;
   background-image: url('./../../assets/gradient.jpeg');
+  display: flex;
+  flex-direction: column;
+  gap: 50px;
 }
 
 .translucent {
@@ -19,8 +22,6 @@
   display: flex;
   justify-content: space-around;
   align-items: center;
-  height: 62vh;
-  padding-top: 100px;
 }
 
 #buy-search {
@@ -28,6 +29,9 @@
   flex-direction: column;
   align-items: center;
   gap: 25px;
+  padding: 25px;
+  border-radius: 25px;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
 }
 
 #filter-search {
@@ -43,8 +47,13 @@
 }
 
 #most-viewed-container {
+  display: flex;
+  flex-direction: column;
   text-align: center;
+  gap: 5px;
   border-radius: 25px;
+  padding: 25px 0;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
 }
 
 .most-viewed-listing {
@@ -68,11 +77,6 @@
   font-size: xx-large;
 }
 
-#favorites-label:hover {
-  color: #42b6ff;
-  text-decoration: underline;
-}
-
 #favorites-container {
   display: flex;
   flex-direction: column;
@@ -94,6 +98,11 @@
 .buy-page-user-selection {
   border: none;
   border-radius: 10px;
+}
+
+#search-button {
+  width: 75%;
+  align-self: center;
 }
 
 #search-button:hover {

--- a/frontend/src/components/css/HomePage.css
+++ b/frontend/src/components/css/HomePage.css
@@ -10,7 +10,7 @@
   flex-direction: column;
   align-items: center;
   padding: 1vh 10vw;
-  gap: 100px;
+  gap: calc(min(40px, 3vh))
 }
 
 #recommended-label {
@@ -31,13 +31,13 @@
   );
 }
 
-.slider:hover .recommended-listing {
+.slider.hover-pause:hover .recommended-listing {
   animation-play-state: paused;
   transition: 0.5s filter;
   filter: blur(3px) brightness(0.5)
 }
 
-.slider .recommended-listing:hover {
+.slider.hover-pause .recommended-listing:hover {
   filter: none;
 }
 
@@ -52,8 +52,8 @@
   width: var(--listing-width);
   position: absolute;
   left: 100%;
-  animation: slide-listings 60s linear infinite;
-  animation-delay: calc((60s / var(--count) * var(--index)));
+  animation: slide-listings calc(var(--count) * 4s) linear infinite;
+  animation-delay: calc(4s * var(--index));
 }
 
 #recommended-car-image {
@@ -94,7 +94,7 @@
 
 @keyframes slide-listings {
   from {
-    left: -550px;
+    left: calc(-1 * var(--listing-width))
   }
   to {
     left: 100%;

--- a/frontend/src/components/css/ResultsPage.css
+++ b/frontend/src/components/css/ResultsPage.css
@@ -16,9 +16,11 @@
   flex-direction: column;
   padding: 2vw;
   border-radius: 15px;
-  height: 75vh;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5);
+  height: fit-content;
+  box-shadow: 0 0px 15px rgba(0, 0, 0, 0.5);
   width: 50%;
+  gap: 40px;
+  align-items: center;
 }
 
 #favorite-search-button {
@@ -31,8 +33,8 @@
   display: flex;
   flex-direction: column;
   padding: 1vh 1vw;
-  height: 100%;
   justify-content: space-between;
+  gap: 10px;
 }
 
 #result-page-location-details {
@@ -73,10 +75,10 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
-  max-height: 92vh;
+  max-height: 142vh;
   overflow-y: scroll;
   overflow-x: visible;
-  padding: 2vw
+  padding: 2vw;
 }
 
 #car-listing-list::-webkit-scrollbar {
@@ -88,7 +90,6 @@
 }
 
 #saved-search-selection-box {
-  margin-top: 75px;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/css/SellPage.css
+++ b/frontend/src/components/css/SellPage.css
@@ -32,7 +32,6 @@
 #sell-content {
   display: flex;
   justify-content: center;
-  /* height: 62vh; */
   padding: 50px;
 }
 
@@ -44,10 +43,11 @@
 }
 
 #new-listing-form {
-  border-radius: 10px;
+  border-radius: 25px;
   display: flex;
   gap: 5.5vw;
   padding: 2vh 2vw;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
 }
 
 #listings-container {
@@ -88,6 +88,7 @@
   margin: 100px;
   gap: 20px;
   border-radius: 10px;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
 }
 
 #price-helper-button {

--- a/frontend/src/components/css/SellerListing.css
+++ b/frontend/src/components/css/SellerListing.css
@@ -29,7 +29,7 @@
 .seller-listing-image {
   width: 240px;
   height: 180px;
-  object-fit: contain;
+  object-fit: cover;
   border-radius: 10px;
 }
 

--- a/frontend/src/components/css/SignupPage.css
+++ b/frontend/src/components/css/SignupPage.css
@@ -24,7 +24,7 @@
 }
 
 #signup-page-content {
-  padding: 10px;
+  padding: 50px;
   position: fixed;
   top: 54%;
   left: 50%;
@@ -34,12 +34,13 @@
   gap: 5px;
   justify-content: center;
   align-items: center;
-  height: 80%;
-  width: 25%;
+  height: fit-content;
+  width: fit-content;
+  width: 20vw;
   min-width: 300px;
   min-height: 200px;
-  /* overflow-y: auto; */
   border-radius: 25px;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
 }
 
 .signup-info {
@@ -49,7 +50,6 @@
   align-items: center;
   width: 100%;
   height: 40px;
-  /* backdrop-filter: blur(30px); */
   background-color: rgba(255, 255, 255, 0.1);
   border-radius: 8px;
 }
@@ -79,11 +79,14 @@
 }
 
 #signup-button {
-  width: 100%;
+  width: 75%;
+  /* border: 1px solid black; */
+  margin-top: 10px;
 }
 
 #signup-account-creation {
   display: flex;
   align-items: center;
   gap: 5px;
+  margin-top: 25px;
 }

--- a/frontend/src/components/css/SingleCarPage.css
+++ b/frontend/src/components/css/SingleCarPage.css
@@ -21,13 +21,15 @@
   flex: 3;
   gap: 50px;
   margin: 100px;
-  max-width: 60vw;
+  max-width: 35vw;
+  flex-grow: 2;
 }
 
 #listing-info {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  flex-grow: 1;
 }
 
 #image-cycler {
@@ -39,6 +41,7 @@
 #single-car-image {
   width: 100%;
   border-radius: 25px;
+  min-width: 400px;
 }
 
 #previous-image {
@@ -62,6 +65,26 @@
   height: 72px;
 }
 
+<<<<<<< Updated upstream
+=======
+#contact-seller-container {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  height: fit-content;
+  min-width: 20vw;
+  margin: 100px;
+  padding: 25px;
+  border-radius: 25px;
+}
+
+#messages {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+>>>>>>> Stashed changes
 #reply-box {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/jsx/BuyPage.jsx
+++ b/frontend/src/components/jsx/BuyPage.jsx
@@ -1,5 +1,4 @@
 import './../css/BuyPage.css'
-import car from './../../assets/car.jpg'
 import arrow from './../../assets/arrow.png'
 import Header from './Header'
 import { useState, useEffect } from 'react'
@@ -145,8 +144,8 @@ function BuyPage() {
       {loaded ? (
         <>
           <div id='buy-content' className='fade'>
-            <div id='buy-search'>
-              <form className='translucent' id='filter-search' onSubmit={handleSearch}>
+            <div id='buy-search' className='translucent'>
+              <form id='filter-search' onSubmit={handleSearch}>
                 <div id='filters'>
                   <label>Condition</label>
                   <select className='translucent buy-page-user-selection pointer' id="condition-selector" name="condition" onChange={updateFilters} required>
@@ -208,9 +207,9 @@ function BuyPage() {
             </div>
             {
               mostDwelledListing &&
-              <div id='most-viewed-container' className='grow'>
+              <div id='most-viewed-container' className='translucent grow'>
                 <h2>Still Interested?</h2>
-                <div className='translucent most-viewed-listing pointer'>
+                <div className='most-viewed-listing pointer'>
                   <img src={mostDwelledListing.images[0]} id='most-viewed-car-img' className='car-image' onClick={() => navigate(`/listing/${mostDwelledListing.vin}`)}/>
                   <div id='most-viewed-car-info'>
                     <p>Make: {mostDwelledListing.make}</p>
@@ -227,7 +226,7 @@ function BuyPage() {
             favoritedListings.length > 0 &&
             (
               <div id='favorites-container' className='fade'>
-                <label id='favorites-label' className='pointer'>Your Favorites</label>
+                <label id='favorites-label'>Your Favorites</label>
                 <div id='favorite-cars'>
                   {
                     page > 1 && (<img src={arrow} height='50px' id='flipped-arrow' className='pointer' onClick={handlePageChange}/>) 

--- a/frontend/src/components/jsx/ResultsPage.jsx
+++ b/frontend/src/components/jsx/ResultsPage.jsx
@@ -227,8 +227,8 @@ function ResultsPage() {
       { loaded ? (
         <div id='result-page-content' className='fade'>
           <div id='result-page-form-content' className='translucent'>
-            <img id='favorite-search-button' className='pointer' height={25} src={isSearchFavorited ? pinkHeart : heart} onClick={handleSearchFavoriteClick}/>
             <form id='advanced-filters' onSubmit={handleSearch}>
+              <img id='favorite-search-button' className='pointer' height={25} src={isSearchFavorited ? pinkHeart : heart} onClick={handleSearchFavoriteClick}/>
               <div className='filter'>
                 <label>Condition</label>
                 <select className='translucent buy-page-user-selection pointer' id="condition-selector" value={onScreenFilters.condition} name="condition" onChange={updateForm} required>
@@ -303,6 +303,7 @@ function ResultsPage() {
                 searchChange && (<button id='result-page-search-button' type='submit'>Search</button>)
               }
             </form>
+            <h3>OR</h3>
             {
               savedSearchFilters.length > 0 && (
                 <div id='saved-search-selection-box'>

--- a/frontend/src/components/jsx/SignupPage.jsx
+++ b/frontend/src/components/jsx/SignupPage.jsx
@@ -42,7 +42,7 @@ function SignupPage() {
         <h2>CarPortal</h2>
       </header>
       <div id='signup-page-overlay'>
-        <form id='signup-page-content' onSubmit={handleSignup} autoComplete='off'>
+        <form id='signup-page-content' className='translucent' onSubmit={handleSignup} autoComplete='off'>
           <h2>Create an Account</h2>
           <h3>{message}</h3>
           {/* TODO: make signup-info's into a component */}


### PR DESCRIPTION
## Description
- Refine sizing of elements to adapt well visually on different screen sizes
- Remove floating elements by adding a translucent background and shadow

## Test Plan
Before
<img width="1512" height="819" alt="image" src="https://github.com/user-attachments/assets/47d73b2f-8bec-4bad-b866-01785b1088da" />

After
<img width="1512" height="820" alt="image" src="https://github.com/user-attachments/assets/a3c7ec4b-20b6-46ac-9b51-e37ab3a4b054" />
